### PR TITLE
댓글 / 게시물 리스트 오른쪽 사이드바 최근게시글 삭제  / 카테고리별 리스트 / 헤더 수정

### DIFF
--- a/udonmarket/src/main/java/com/kh/udon/community/controller/CommunityController.java
+++ b/udonmarket/src/main/java/com/kh/udon/community/controller/CommunityController.java
@@ -9,11 +9,14 @@ import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.kh.udon.community.model.service.CommunityService;
 import com.kh.udon.community.model.vo.Community;
+import com.kh.udon.community.model.vo.Reply;
 import com.kh.udon.community.model.vo.Search;
 
 import lombok.extern.slf4j.Slf4j;
@@ -36,7 +39,8 @@ public class CommunityController
 	public String CommunityList(/* @RequestParam int categoryCode, */
     						Model model
     						, @RequestParam(required = false, defaultValue = "board_title") String searchType
-    						, @RequestParam(required = false) String keyword) {
+    						, @RequestParam(required = false) String keyword
+    						, @RequestParam(required = false) String categoryCode) {
 //							, @RequestParam(defaultValue = "1", 
 //								value = "cPage") int cPage) {
 				//1.사용자 입력값 
@@ -44,15 +48,22 @@ public class CommunityController
 //				int offset = (cPage - 1) * limit;
     	
 		    	Search search = new Search();
+//		    	Community community = new Community();
 		
 				search.setSearchType(searchType);
 		
 				search.setKeyword(keyword);
 				
+				search.setCategoryCode(categoryCode);
+				
+				/* community.setCategoryCode(categoryCode); */
+				
 				//2. 업무로직
 				List<Community> list = service.selectCommunityList(search);
+				/* List<Community> list2 = service.selectCommunityList(categoryCode); */
 //				Community community = service.selectCategory(categoryCode);
 				log.debug("list = {}", list);
+				/* log.debug("list = {}", list2); */
 //				log.debug("Community = {}", community);
 				
 				//전체컨텐츠수 구하기
@@ -63,14 +74,15 @@ public class CommunityController
 //				mav.addObject("totalContents", totalContents);
 //				model.addAttribute("community", community);
 				model.addAttribute("list", list);
+				/* model.addAttribute("list", list2); */
 				return "community/communityListView";
     }
     
     @RequestMapping("/communityDetailView")
     public String communityDetail(@RequestParam int bCode,
-			  Model model, 
+			  Model model,
 			  @RequestParam(required = false, defaultValue = "board_title") String searchType
-				, @RequestParam(required = false) String keyword) {
+				, @RequestParam(required = false) String keyword) throws Exception {
 		
     	Search search = new Search();
 		
@@ -80,11 +92,13 @@ public class CommunityController
     	
     			Community community = service.selectOneCommunityCollection(bCode);
     			List<Community> list = service.selectCommunityList(search);
+    			List<Reply> replyList = service.ReplyList(bCode);
     			log.debug("Community = {}", community);
 				log.debug("list = {}", list);
 
     			model.addAttribute("community", community);
     			model.addAttribute("list", list);
+    			model.addAttribute("replyList", replyList);
     			return "community/communityDetailView";
     }
     
@@ -94,6 +108,19 @@ public class CommunityController
     	return "community/communityForm";
     	
     }
+    
+
+	@RequestMapping(value="/saveReply", method = RequestMethod.POST)
+	public String saveReply(Reply reply, RedirectAttributes rttr) throws Exception {
+		log.info("saveReply");
+		
+		service.saveReply(reply);
+		
+		rttr.addAttribute("bCode", reply.getBCode());
+
+		
+		return "redirect:/community/communityListView";
+	}
     
 }
 

--- a/udonmarket/src/main/java/com/kh/udon/community/controller/RestBoardController.java
+++ b/udonmarket/src/main/java/com/kh/udon/community/controller/RestBoardController.java
@@ -1,0 +1,85 @@
+package com.kh.udon.community.controller;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+
+
+import org.slf4j.Logger;
+
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import org.springframework.web.bind.annotation.RequestParam;
+
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kh.udon.community.model.service.CommunityService;
+import com.kh.udon.community.model.vo.Reply;
+
+
+
+
+
+@RestController
+
+@RequestMapping(value = "/restBoard")
+
+public class RestBoardController {
+
+
+
+	private static final Logger logger = LoggerFactory.getLogger(CommunityController.class);
+
+
+
+	@Inject
+
+	private CommunityService communityService;
+
+	
+
+	@RequestMapping(value = "/ReqlyList", method = RequestMethod.POST)
+
+	public List<Reply> ReplyList(@RequestParam("bCode") int bCode) throws Exception {
+
+		return communityService.ReplyList(bCode);
+
+	}
+	
+	@RequestMapping(value = "/saveReqly", method = RequestMethod.POST)
+
+	public Map<String, Object> saveReply(@RequestBody Reply reply) throws Exception {
+
+		Map<String, Object> result = new HashMap<>();
+
+		
+
+		try {
+
+			communityService.saveReply(reply);
+
+			result.put("status", "OK");
+
+		} catch (Exception e) {
+
+			e.printStackTrace();
+
+			result.put("status", "False");
+
+		}
+
+		
+
+		return result;
+
+	}
+
+}
+

--- a/udonmarket/src/main/java/com/kh/udon/community/model/dao/CommunityDao.java
+++ b/udonmarket/src/main/java/com/kh/udon/community/model/dao/CommunityDao.java
@@ -3,6 +3,7 @@ package com.kh.udon.community.model.dao;
 import java.util.List;
 
 import com.kh.udon.community.model.vo.Community;
+import com.kh.udon.community.model.vo.Reply;
 import com.kh.udon.community.model.vo.Search;
 
 
@@ -10,9 +11,24 @@ public interface CommunityDao
 {
 
 	List<Community> selectCommunityList(Search search);
+	/* List<Community> selectCommunityList(int categoryCode); */
 	
 	Community selectOneCommunityCollection(int bCode);
 	
 //	Community selectCategory(int categoryCode);
+	
+	public List<Reply> ReplyList(int bCode) throws Exception;
+
+	
+
+	public int saveReply(Reply reply) throws Exception;
+
+	
+
+	public int updateReply(Reply reply) throws Exception;
+
+	
+
+	public int deleteReply(int replyCode) throws Exception;
 	
 }

--- a/udonmarket/src/main/java/com/kh/udon/community/model/dao/CommunityDaoImpl.java
+++ b/udonmarket/src/main/java/com/kh/udon/community/model/dao/CommunityDaoImpl.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import com.kh.udon.community.model.vo.Community;
+import com.kh.udon.community.model.vo.Reply;
 import com.kh.udon.community.model.vo.Search;
 
 
@@ -23,6 +24,12 @@ public class CommunityDaoImpl implements CommunityDao
 		return session.selectList("community.selectCommunityList", search);
 	}
     
+	/*
+	 * @Override public List<Community> selectCommunityList(int categoryCode) { //
+	 * RowBounds rowBounds = new RowBounds(); return
+	 * session.selectList("community.selectCommunityList", categoryCode); }
+	 */
+    
     @Override
 	public Community selectOneCommunityCollection(int bCode) {
 		return session.selectOne("community.selectOneCommunityCollection", bCode);
@@ -33,5 +40,44 @@ public class CommunityDaoImpl implements CommunityDao
 //		return session.selectOne("community.selectCategory", categoryCode);
 //	}
     
+    @Override
+
+	public List<Reply> ReplyList(int bCode) throws Exception {
+
+		return session.selectList("communityReply.ReplyList", bCode);
+
+	}
+
+
+
+	@Override
+
+	public int saveReply(Reply reply) throws Exception {
+
+		return session.insert("communityReply.saveReply", reply);
+
+	}
+
+
+
+	@Override
+
+	public int updateReply(Reply reply) throws Exception {
+
+		return session.update("communityReply.updateReply", reply);
+
+	}
+
+
+
+	@Override
+
+	public int deleteReply(int replyCode) throws Exception {
+
+		return session.delete("communityReply.deleteReply", replyCode);
+
+	}
+
+
 
 }

--- a/udonmarket/src/main/java/com/kh/udon/community/model/service/CommunityService.java
+++ b/udonmarket/src/main/java/com/kh/udon/community/model/service/CommunityService.java
@@ -3,6 +3,7 @@ package com.kh.udon.community.model.service;
 import java.util.List;
 
 import com.kh.udon.community.model.vo.Community;
+import com.kh.udon.community.model.vo.Reply;
 import com.kh.udon.community.model.vo.Search;
 
 
@@ -10,11 +11,27 @@ public interface CommunityService
 {
 
 	List<Community> selectCommunityList(Search search);
+	/* List<Community> selectCommunityList(int categoryCode); */
 	
 	Community selectOneCommunityCollection(int bCode);
 
 //	Community selectCategory(int categoryCode);
 
 //	int selectBoardTotalContents();
+
+	public List<Reply> ReplyList(int bCode) throws Exception;
+
+	
+
+	public int saveReply(Reply reply) throws Exception;
+
+	
+
+	public int updateReply(Reply reply) throws Exception;
+
+	
+
+	public int deleteReply(int replyCode) throws Exception;
+
 	
 }

--- a/udonmarket/src/main/java/com/kh/udon/community/model/service/CommunityServiceImpl.java
+++ b/udonmarket/src/main/java/com/kh/udon/community/model/service/CommunityServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 
 import com.kh.udon.community.model.dao.CommunityDao;
 import com.kh.udon.community.model.vo.Community;
+import com.kh.udon.community.model.vo.Reply;
 import com.kh.udon.community.model.vo.Search;
 
 @Service
@@ -20,6 +21,11 @@ public class CommunityServiceImpl implements CommunityService
 		return dao.selectCommunityList(search);
 	}
     
+	/*
+	 * @Override public List<Community> selectCommunityList(int categoryCode) {
+	 * return dao.selectCommunityList(categoryCode); }
+	 */
+    
     @Override
 	public Community selectOneCommunityCollection(int bCode) {
 		return dao.selectOneCommunityCollection(bCode);
@@ -29,5 +35,45 @@ public class CommunityServiceImpl implements CommunityService
 //   	public Community selectCategory(int categoryCode) {
 //   		return dao.selectCategory(categoryCode);
 //   	}
+    
+    @Override
+
+	public List<Reply> ReplyList(int bCode) throws Exception {
+
+		return dao.ReplyList(bCode);
+
+	}
+
+
+
+	@Override
+
+	public int saveReply(Reply reply) throws Exception {
+
+		return dao.saveReply(reply);
+
+	}
+
+
+
+	@Override
+
+	public int updateReply(Reply reply) throws Exception {
+
+		return dao.updateReply(reply);
+
+	}
+
+
+
+	@Override
+
+	public int deleteReply(int replyCode) throws Exception {
+
+		return dao.deleteReply(replyCode);
+
+	}
+
+
     
 }

--- a/udonmarket/src/main/java/com/kh/udon/community/model/vo/Reply.java
+++ b/udonmarket/src/main/java/com/kh/udon/community/model/vo/Reply.java
@@ -1,0 +1,27 @@
+package com.kh.udon.community.model.vo;
+
+import java.io.Serializable;
+import java.util.Date;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class Reply implements Serializable {
+
+	private int replyCode;
+	private int replyLevel;
+	private String userId;
+	private String content;
+	private int bCode;
+	private int reply_ref;
+	private Date regDate;
+	
+}

--- a/udonmarket/src/main/java/com/kh/udon/community/model/vo/Search.java
+++ b/udonmarket/src/main/java/com/kh/udon/community/model/vo/Search.java
@@ -18,5 +18,7 @@ public class Search {
 	private String searchType;
 
 	private String keyword;	
+	
+	private String categoryCode;
 
 }

--- a/udonmarket/src/main/resources/mapper/community-mapper.xml
+++ b/udonmarket/src/main/resources/mapper/community-mapper.xml
@@ -20,6 +20,31 @@
 				AND board_content like CONCAT('%' || #{keyword}, '%')
 
 			</if>
+			
+			<if test="categoryCode==17">
+
+				AND category_code = 17
+
+			</if>
+			
+			<if test="categoryCode==18">
+
+				AND category_code = 18
+
+			</if>
+			
+			<if test="categoryCode==19">
+
+				AND category_code = 19
+
+			</if>
+			
+			<if test="categoryCode==20">
+
+				AND category_code = 20
+
+			</if>
+			
 
 		</trim> 
 		order by b_code desc

--- a/udonmarket/src/main/resources/mapper/communityReply-mapper.xml
+++ b/udonmarket/src/main/resources/mapper/communityReply-mapper.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+<mapper namespace="communityReply">
+<select id="ReplyList" resultType="Reply">
+
+		SELECT
+
+			reply_code
+
+			, b_code
+
+			, content
+
+			, user_id
+
+			, reg_date
+
+
+		FROM
+
+			reply
+
+		WHERE
+
+			b_code = #{bCode}
+
+		ORDER BY reg_date desc
+
+	</select>
+	
+	<insert id="saveReply" parameterType="com.kh.udon.community.model.vo.Reply">
+
+		insert into reply values(
+    		seq_reply.nextval,
+		    1,
+		    #{userId},
+		    #{content},
+		    #{bCode},
+		    null,
+		    sysdate
+		)
+
+	</insert>
+
+	
+
+	<update id="updateReply" parameterType="com.kh.udon.community.model.vo.Reply">
+
+		UPDATE reply SET
+
+			content = #{content}
+
+		WHERE
+
+			reply_code = #{replyCode}
+
+	</update>
+
+	
+
+	<delete id="deleteReply" parameterType="int">
+
+		DELETE FROM reply
+
+		WHERE
+
+			reply_code = #{replyCode}
+
+	</delete>
+	
+</mapper>

--- a/udonmarket/src/main/webapp/WEB-INF/views/common/header.jsp
+++ b/udonmarket/src/main/webapp/WEB-INF/views/common/header.jsp
@@ -75,10 +75,10 @@
                                         role="button" aria-haspopup="true" aria-expanded="false">동네생활
                                     </a>
                                     <div class="dropdown-menu" aria-labelledby="navbarDropdown_1">
-                                        <a class="dropdown-item" href="/">동네생활이야기</a>
-                                        <a class="dropdown-item" href="/">우리동네질문</a>
-										<a class="dropdown-item" href="/">분실/실종센터</a>
-										<a class="dropdown-item" href="/">동네사건사고</a>
+                                        <a class="dropdown-item" href="/udon/community/communityListView?categoryCode=17">동네생활이야기</a>
+                                        <a class="dropdown-item" href="/udon/community/communityListView?categoryCode=18">우리동네질문</a>
+										<a class="dropdown-item" href="/udon/community/communityListView?categoryCode=19">분실/실종센터</a>
+										<a class="dropdown-item" href="/udon/community/communityListView?categoryCode=20">동네사건사고</a>
                                     </div>
                                 </li>
 								<!--관리자메뉴 -->

--- a/udonmarket/src/main/webapp/WEB-INF/views/community/communityDetailView.jsp
+++ b/udonmarket/src/main/webapp/WEB-INF/views/community/communityDetailView.jsp
@@ -3,6 +3,8 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions"%>
+<%@ taglib prefix="form" uri="http://www.springframework.org/tags/form" %>
+
 
 <fmt:requestEncoding value="utf-8"/>
 
@@ -11,6 +13,8 @@
 </jsp:include>
 
 <script>
+
+
 
 $(function(){
 
@@ -36,6 +40,14 @@ $(document).on('click', '#btnSearch', function(e){
 		console.log(url);
 
 	});	
+
+
+$(".replyWriteBtn").on("click", function(){
+  var formObj = $("form[name='replyForm']");
+  formObj.attr("action", "/saveReply");
+  formObj.submit();
+});
+
 
 </script>
 
@@ -175,8 +187,52 @@ $(document).on('click', '#btnSearch', function(e){
                   </div>
                </div>
                
-               <div class="comments-area">
+               <!-- 댓글 -->
+               <%-- <div class="my-3 p-3 bg-white rounded shadow-sm" style="padding-top: 10px">
+
+				<form:form name="form" id="form" role="form" modelAttribute="reply" method="post">
+
+				<form:hidden path="bCode" id="bCode"/>
+
+				<div class="row">
+
+					<div class="col-sm-10">
+
+						<form:textarea path="content" id="content" class="form-control" rows="3" placeholder="댓글을 입력해 주세요"></form:textarea>
+
+					</div>
+
+					<div class="col-sm-2">
+
+						<form:input path="userId" class="form-control" id="userId" value="test"></form:input>
+
+						<button type="button" class="btn btn-sm btn-primary" id="btnReplySave" style="width: 100%; margin-top: 10px"> 저 장 </button>
+
+					</div>
+
+				</div>
+
+				</form:form>
+
+			</div>
+
+			
+
+			
+
+			
+
+			<div class="my-3 p-3 bg-white rounded shadow-sm" style="padding-top: 10px">
+
+				<h6 class="border-bottom pb-2 mb-0">댓글</h6>
+
+				<div id="replyList"></div>
+
+			</div>  --%>
+
+	<div class="comments-area">
                   <h4>댓글 <span style="color: red">3</span></h4>
+				<c:forEach items="${replyList}" var="r">
                   <div class="comment-list">
                      <div class="single-comment justify-content-between d-flex">
                         <div class="user justify-content-between d-flex">
@@ -185,95 +241,45 @@ $(document).on('click', '#btnSearch', function(e){
                            </div>
                            <div class="desc">
                               <p class="comment">
-                                	댓글내용
+                                	${r.content}
                               </p>
                               <div class="d-flex justify-content-between">
                                  <div class="d-flex align-items-center">
                                     <h5>
-                                       <a href="#">닉네임</a>
+                                       <a href="#">${r.userId}</a>
                                     </h5>
-                                    <p class="date"> 2020. 09. 24 </p>
+                                    <p class="date"> <fmt:formatDate value="${r.regDate}" pattern="yyyy-MM-dd" /> </p>
                                       &nbsp;&nbsp; &nbsp;&nbsp;
                                     <a href="#">신고하기</a>
                                  </div>
-                                 <div class="reply-btn">
-                                    <a href="#" class="btn-reply text-uppercase">reply</a>
-                                 </div>
+                                 
                               </div>
                            </div>
                         </div>
-                     </div>
-                  </div>
-                  <div class="comment-list">
-                     <div class="single-comment justify-content-between d-flex">
-                        <div class="user justify-content-between d-flex">
-                           <div class="thumb">
-                              <img src="${pageContext.request.contextPath}/resources/img/comment/comment_1.png" alt="">
-                           </div>
-                           <div class="desc">
-                              <p class="comment">
-                                	댓글내용
-                              </p>
-                              <div class="d-flex justify-content-between">
-                                 <div class="d-flex align-items-center">
-                                    <h5>
-                                       <a href="#">닉네임</a>
-                                    </h5>
-                                    <p class="date"> 2020. 09. 24 </p>
-                                      &nbsp;&nbsp; &nbsp;&nbsp;
-                                    <a href="#">신고하기</a>
-                                 </div>
-                                 <div class="reply-btn">
-                                    <a href="#" class="btn-reply text-uppercase">reply</a>
-                                 </div>
-                              </div>
-                           </div>
                         </div>
                      </div>
+					</c:forEach>   
                   </div>
-                  <div class="comment-list">
-                     <div class="single-comment justify-content-between d-flex">
-                        <div class="user justify-content-between d-flex">
-                           <div class="thumb">
-                              <img src="${pageContext.request.contextPath}/resources/img/comment/comment_1.png" alt="">
-                           </div>
-                           <div class="desc">
-                              <p class="comment">
-                                	댓글내용
-                              </p>
-                              <div class="d-flex justify-content-between">
-                                 <div class="d-flex align-items-center">
-                                    <h5>
-                                       <a href="#">닉네임</a>
-                                    </h5>
-                                    <p class="date"> 2020. 09. 24 </p>
-                                      &nbsp;&nbsp; &nbsp;&nbsp;
-                                    <a href="#">신고하기</a>
-                                 </div>
-                                 <div class="reply-btn">
-                                    <a href="#" class="btn-reply text-uppercase">reply</a>
-                                 </div>
-                              </div>
-                           </div>
-                        </div>
-                     </div>
-                  </div>
-               </div>
-               <div class="comment-form">
-                  <form class="form-contact comment_form" action="#" id="commentForm">
+                  <div class="comment-form">
+                  <form class="form-contact comment_form" id="replyForm" name="replyForm" method="post">
                      <div class="row">
                         <div class="col-12">
                            <div class="form-group">
+                           <input type="hidden" id="bCode" name="bCode" value="${community.BCode}" />
+                           <input type="hidden" id="userId" name="userId" value="test" />
                               <textarea class="form-control w-100" name="comment" id="comment" cols="30" rows="5"
                                  placeholder="댓글 작성 시 타인에 대한 배려와 책임을 담아주세요."></textarea>
                            </div>
                         </div>
                      </div>
                      <div class="form-group mt-3">
-                        <a href="#" class="btn_3 button-contactForm">등록</a>
+                        <button type="button" class="replyWriteBtn">작성</button>
                      </div>
                   </form>
                </div>
+
+               
+               
             </div>
             <div class="col-lg-4">
                     <div class="blog_right_sidebar">
@@ -312,22 +318,22 @@ $(document).on('click', '#btnSearch', function(e){
                             <h4 class="widget_title">카테고리</h4>
                             <ul class="list cat-list">
                                 <li>
-                                    <a href="#" class="d-flex">
+                                    <a href="communityListView?categoryCode=17" class="d-flex">
                                         <p>동네생활이야기</p>
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="#" class="d-flex">
+                                    <a href="communityListView?categoryCode=18" class="d-flex">
                                         <p>우리동네질문</p>
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="#" class="d-flex">
+                                    <a href="communityListView?categoryCode=19" class="d-flex">
                                         <p>분실/실종센터</p>
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="#" class="d-flex">
+                                    <a href="communityListView?categoryCode=20" class="d-flex">
                                         <p>동네사건사고</p>
                                     </a>
                                 </li>

--- a/udonmarket/src/main/webapp/WEB-INF/views/community/communityListView.jsp
+++ b/udonmarket/src/main/webapp/WEB-INF/views/community/communityListView.jsp
@@ -39,7 +39,14 @@ $(document).on('click', '#btnSearch', function(e){
 
 
 
+$(function(){
 
+	$("a[data-category-code]").click(function(){
+		var categoryCode = $(this).attr("data-category-code");
+		location.href = "${ pageContext.request.contextPath }/community/communityListView?categoryCode=" + categoryCode;
+	});
+	
+});
 
 
 
@@ -197,44 +204,29 @@ $(document).on('click', '#btnSearch', function(e){
                             <h4 class="widget_title">카테고리</h4>
                             <ul class="list cat-list">
                                 <li>
-                                    <a href="communityListView?categoryCode=17" class="d-flex">
+                                    <a data-category-code="17" class="d-flex">
                                         <p>동네생활이야기</p>
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="communityListView?categoryCode=18" class="d-flex">
+                                    <a data-category-code="18" class="d-flex">
                                         <p>우리동네질문</p>
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="communityListView?categoryCode=19" class="d-flex">
+                                    <a data-category-code="19" class="d-flex">
                                         <p>분실/실종센터</p>
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="communityListView?categoryCode=20" class="d-flex">
+                                    <a data-category-code="20" class="d-flex">
                                         <p>동네사건사고</p>
                                     </a>
                                 </li>
                             </ul>
                         </aside>
 
-                        <aside class="single_sidebar_widget popular_post_widget">
-                            <h3 class="widget_title">최근 게시글</h3>
-                           
-                           <c:forEach var="c" items="${ list }"  begin="0" end="3" step="1">
-								<div class="media post_item">
-									<a data-board-no="${ c.BCode }">
-									<img src="${pageContext.request.contextPath}/resources/img/blog/no_img.png" alt="post" style="width: 42px; height: 42px">
-									<div class="media-body">
-										<h3 style="font-weight: bold;">${c.boardTitle}</h3>
-									<p><fmt:formatDate value="${ c.regDate }" type="both"/></p>
-									</a>
-									</div>
-								</div>
-							</c:forEach>
-                           
-                        </aside>
+                        
                         <aside class="single_sidebar_widget tag_cloud_widget">
                             <h4 class="widget_title">태그</h4>
                             <ul class="list">


### PR DESCRIPTION
댓글 - 등록은 에러 때문에 리스트만
게시물 리스트 오른쪽 사이드바 최근게시글 삭제 - 게시글 상세보기에선 나옴
카테고리별 리스트 - 사이드바에서 카테고리 누르면 해당 카테고리 게시글만 보여줌
헤더 수정 - 메뉴에서 동네생활 카테고리 누르면 카테고리별 리스트 나오게 변경